### PR TITLE
Update import std experimental string for 4.3 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.31) # Raise to 4.3 on availability global release and availability in CI/CD
+cmake_minimum_required(VERSION 3.31) 
 
-set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD "d0edc3af-4c50-42ea-a356-e2862fe7a444") # Should be removed after 4.3 is released
+set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD "451f2fe2-a8a2-47c3-bc32-94786d8fc91b") 
 
 include(cmake/prelude.cmake)
 


### PR DESCRIPTION
Initially, CMake planned to remove experimental status from `import std` functionality but for some reason this was reverted and the string was changed. This changes experimental string to the one from 4.3. This also means that for modules CMake 4.3 is now required.