### PR TITLE
Update workflows to ubuntu-26.04

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -17,14 +17,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DoozyX/clang-format-lint-action@v0.16.2
+      - uses: DoozyX/clang-format-lint-action@v0.20
         with:
           source: '.'
           exclude: ''
           extensions: 'h,hpp,cpp'
-          clangFormatVersion: 16
+          clangFormatVersion: 20
           style: file
           inplace: True
-      - uses: EndBug/add-and-commit@v9
+      - uses: EndBug/add-and-commit@v10
         with:
           message: 'Committing clang-format changes'

--- a/.github/workflows/clang-linux.yml
+++ b/.github/workflows/clang-linux.yml
@@ -15,12 +15,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     strategy:
       fail-fast: false
       matrix:
-        clang: [17, 18]
+        clang: [21, 22]
         build_type: [Debug]
         std: [23]
 

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -15,12 +15,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     
     strategy:
       fail-fast: false
       matrix:
-        gcc: [13, 14]
+        gcc: [14, 15]
         build_type: [Debug]
         std: [23]
 

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -24,19 +24,20 @@ jobs:
             configure_preset: "x64-vs"
             build_preset: "x64-vs-build"
             test_preset : "x64-vs-test"
-          # To be uncommented  once GitHub Actions add GCC 15 or 16 with Ubuntu 26
-          # - runs_on: ubuntu-latest
-          #  compiler: gcc-15
-          # configure_preset: "linux-debug"
-          # build_preset: "linux-debug-build"
-          # test_preset : "linux-debug-test"
-          # - runs_on: ubuntu-latest
-          # compiler: clang-18
-          # cc: clang
-          # cxx: clang++
-          # configure_preset: "linux-debug"
-          # build_preset: "linux-debug-build"
-          # test_preset : "linux-debug-test"
+          - runs_on: ubuntu-26.04
+            compiler: gcc-15
+            cc: gcc-15
+            cxx: g++-15
+            configure_preset: "linux"
+            build_preset: "linux-build"
+            test_preset : "linux-test"
+          - runs_on: ubuntu-26.04
+            compiler: clang-22
+            cc: clang-22
+            cxx: clang++-22
+            configure_preset: "linux"
+            build_preset: "linux-build"
+            test_preset : "linux-test"
     steps:
 
     - uses: actions/checkout@v6

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -45,15 +45,6 @@
       }
     },
     {
-      "name": "x64-preview",
-      "displayName": "x64 Debug (MSVC v14.51 Preview)",
-      "inherits": "windows-base-preview",
-      "architecture": {
-        "value": "x64",
-        "strategy": "external"
-      }
-    },
-    {
       "name": "windows-vs-base",
       "hidden": true,
       "generator": "Visual Studio 18 2026",
@@ -72,8 +63,8 @@
       "architecture": "x64"
     },
     {
-      "name": "linux-debug",
-      "displayName": "Linux Debug",
+      "name": "linux",
+      "displayName": "Linux Debug (CI)",
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/out/build/${presetName}",
       "installDir": "${sourceDir}/out/install/${presetName}",
@@ -98,12 +89,8 @@
       "configuration": "Debug"
     },
     {
-      "name": "x64-preview-build",
-      "configurePreset": "x64-preview"
-    },
-    {
-      "name": "linux-debug-build",
-      "configurePreset": "linux-debug"
+      "name": "linux-build",
+      "configurePreset": "linux"
     }
   ],
   "testPresets": [
@@ -121,12 +108,8 @@
       }
     },
     {
-      "name": "x64-preview-test",
-      "configurePreset": "x64-preview"
-    },
-    {
-      "name": "linux-debug-test",
-      "configurePreset": "linux-debug"
+      "name": "linux-test",
+      "configurePreset": "linux"
     }
   ]
 }


### PR DESCRIPTION
The PR updates CI workflows to use the `ubuntu-26.04`. The Linux compilers tested in CI are now GCC 14-15 and Clang 21-22. This also allows us to finally test modules build on Linux. Finally, this updates dependencies to the latest available versions.